### PR TITLE
修复了DPI不为100时, CLabelUI(含派生于它的CButtonUI控件)的size不正确的问题

### DIFF
--- a/DuiLib/Control/UILabel.cpp
+++ b/DuiLib/Control/UILabel.cpp
@@ -111,7 +111,14 @@ namespace DuiLib
 
 	SIZE CLabelUI::EstimateSize(SIZE szAvailable)
 	{
-		if (m_cxyFixed.cx > 0 && m_cxyFixed.cy > 0) return m_cxyFixed;
+        if (m_cxyFixed.cx > 0 && m_cxyFixed.cy > 0) {
+            // Jeffery: 
+            // (2018/10/23) 修复了DPI不为100时, CLabelUI(含派生于它的CButtonUI控件)的size不正确的问题
+            //
+            if (m_pManager != NULL)
+                return m_pManager->GetDPIObj()->Scale(m_cxyFixed);
+            return m_cxyFixed;
+        }
 
 		if ((szAvailable.cx != m_szAvailableLast.cx || szAvailable.cy != m_szAvailableLast.cy)) {
 			m_bNeedEstimateSize = true;


### PR DESCRIPTION
```
SIZE CLabelUI::EstimateSize(SIZE szAvailable)
	{
        if (m_cxyFixed.cx > 0 && m_cxyFixed.cy > 0) {
            // Jeffery: 
            // (2018/10/23) 修复了DPI不为100时, CLabelUI(含派生于它的CButtonUI控件)的size不正确的问题
            //
            if (m_pManager != NULL) 
                return m_pManager->GetDPIObj()->Scale(m_cxyFixed);
            return m_cxyFixed;
        }

....
}
```